### PR TITLE
Clean up and organize IdentityAggregator.sol and tests

### DIFF
--- a/backend/contracts/IdentityAggregator.sol
+++ b/backend/contracts/IdentityAggregator.sol
@@ -2,9 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "hardhat/console.sol";
-// import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-// import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-// import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./VerifyJWT.sol";
@@ -14,26 +11,19 @@ contract IdentityAggregator is Ownable  {
 
     mapping(string => address) public contractAddrForKeyword; // e.g., "orcid" => VerifyJWT(orcidContractAddress)
 
-    // Allows easier lookup for keywords // NOTE: Don't need this if our only accessor func is getAllAccounts()
-    mapping(string => string) private keywordForKeyword;
+    mapping(string => string) private keywordForKeyword; // Allows easier lookup for keywords
 
-    string[] private keywords; // e.g., "orcid" // TODO: Better name than 'keywords'??
+    string[] private keywords; // e.g., "orcid"
 
 
     event AddSupportForContract(string contractKeyword);
     event RemoveSupportForContract(string contractKeyword);
 
 
-    constructor() {
-        
-    }
-
-
     /// @notice Add support for a new VerifyJWT contract.
     /// @param keyword The string used to denote the source of the JWT (e.g., "twitter").
     /// @param contractAddress The address of the JWT contract to be supported.
-    function addPlatformContract(string memory keyword, address contractAddress) public onlyOwner { // TODO: there must be a better way than onlyOwner
-
+    function addVerifyJWTContract(string memory keyword, address contractAddress) public onlyOwner {
         // Require that neither this keyword nor this contract has been added
         require(bytes(keywordForKeyword[keyword]).length == 0);
         require(contractAddrForKeyword[keyword] == address(0));
@@ -45,10 +35,9 @@ contract IdentityAggregator is Ownable  {
         emit AddSupportForContract(keyword);
     }
 
-    // TODO: Is there a way to store keywords that allows iteration but allows removal without iteration?
     /// @notice Remove support for a VerifyJWT contract.
     /// @param keyword The string used to lookup the contract.
-    function removeSupportFor(string memory keyword) public onlyOwner { // TODO: there must be a better way than onlyOwner
+    function removeSupportFor(string memory keyword) public onlyOwner {
         require(contractAddrForKeyword[keyword] != address(0), "There is no corresponding contract for this keyword.");
         
         for (uint i = 0; i < keywords.length; i++) {
@@ -79,37 +68,6 @@ contract IdentityAggregator is Ownable  {
             }
         }
         return allCreds;
-    }
-
-    // TODO: Either delete this function, or find a better implementation.
-    // e.g., keyword1 == "orcid", creds1 == "12345...", keyword2 == "twitter" ---> returns "@somehandle"
-    function getCredsFromCreds(
-        string memory keyword1, 
-        bytes calldata creds1, // TODO: Make these parameters fixed-length
-        string memory keyword2
-        ) 
-        public returns (bytes memory creds2) {
-
-        // Require that we have stored the contracts for the specified keywords
-        require(bytes(keywordForKeyword[keyword1]).length != 0);
-        require(bytes(keywordForKeyword[keyword2]).length != 0);
-
-        // Get user address
-        address creds1ContractAddr = contractAddrForKeyword[keyword1];
-        VerifyJWT creds1Contract = VerifyJWT(creds1ContractAddr);
-        address userAddr = creds1Contract.addressForCreds(creds1);
-
-        string memory errorMessage = string(abi.encodePacked("This user has no creds for ", keyword1));
-        require(userAddr != address(0), errorMessage);
-
-        address creds2ContractAddr = contractAddrForKeyword[keyword2];
-        VerifyJWT creds2Contract = VerifyJWT(creds2ContractAddr);
-        bytes memory creds2 = creds2Contract.credsForAddress(userAddr);
-
-        errorMessage = string(abi.encodePacked("This user has no creds for ", keyword2));
-        require(creds2.length != 0);
-
-        return creds2;
     }
 
     function getKeywords() public view returns (string[] memory) {

--- a/backend/contracts/IdentityAggregator.sol
+++ b/backend/contracts/IdentityAggregator.sol
@@ -37,7 +37,7 @@ contract IdentityAggregator is Ownable  {
     /// @notice Remove support for a VerifyJWT contract.
     /// @param keyword The string used to lookup the contract.
     function removeSupportFor(string calldata keyword) public onlyOwner {
-        require(contractAddrForKeyword[keyword] != address(0), "There is no corresponding contract for this keyword.");
+        require(contractAddrForKeyword[keyword] != address(0), "There is no corresponding contract for this keyword");
         
         for (uint i = 0; i < keywords.length; i++) {
             if (keccak256(bytes(keywords[i])) == keccak256(bytes(keyword))) {

--- a/backend/contracts/IdentityAggregator.sol
+++ b/backend/contracts/IdentityAggregator.sol
@@ -23,7 +23,7 @@ contract IdentityAggregator is Ownable  {
     /// @notice Add support for a new VerifyJWT contract.
     /// @param keyword The string used to denote the source of the JWT (e.g., "twitter").
     /// @param contractAddress The address of the JWT contract to be supported.
-    function addVerifyJWTContract(string memory keyword, address contractAddress) public onlyOwner {
+    function addVerifyJWTContract(string calldata keyword, address contractAddress) public onlyOwner {
         // Require that neither this keyword nor this contract has been added
         require(bytes(keywordForKeyword[keyword]).length == 0);
         require(contractAddrForKeyword[keyword] == address(0));
@@ -37,7 +37,7 @@ contract IdentityAggregator is Ownable  {
 
     /// @notice Remove support for a VerifyJWT contract.
     /// @param keyword The string used to lookup the contract.
-    function removeSupportFor(string memory keyword) public onlyOwner {
+    function removeSupportFor(string calldata keyword) public onlyOwner {
         require(contractAddrForKeyword[keyword] != address(0), "There is no corresponding contract for this keyword.");
         
         for (uint i = 0; i < keywords.length; i++) {

--- a/backend/contracts/IdentityAggregator.sol
+++ b/backend/contracts/IdentityAggregator.sol
@@ -25,8 +25,7 @@ contract IdentityAggregator is Ownable  {
     /// @param contractAddress The address of the JWT contract to be supported.
     function addVerifyJWTContract(string calldata keyword, address contractAddress) public onlyOwner {
         // Require that neither this keyword nor this contract has been added
-        require(bytes(keywordForKeyword[keyword]).length == 0);
-        require(contractAddrForKeyword[keyword] == address(0));
+        require(bytes(keywordForKeyword[keyword]).length == 0, "This keyword is already being used");
 
         keywords.push(keyword);
         keywordForKeyword[keyword] = keyword;

--- a/backend/test/identityAggregator.js
+++ b/backend/test/identityAggregator.js
@@ -5,49 +5,19 @@ const { solidity } = require("ethereum-waffle");
 const search64 = require('../../../whoisthis.wtf-frontend/src/searchForPlaintextInBase64.js');
 // import { fixedBufferXOR as xor, sandwichIDWithBreadFromContract, padBase64, hexToString, searchForPlainTextInBase64 } from 'wtfprotocol-helpers';
 const { hexToString } = require('wtfprotocol-helpers');
-
+const {
+  orcidKid, orcidBotomBread, orcidTopBread,
+  deployVerifyJWTContract,
+  deployIdAggregator,
+  sha256FromString,
+  sandwichIDWithBreadFromContract,
+  jwksKeyToPubkey,
+} = require('./utils/utils');
 
 // chai.use(solidity);
 
 
-//-------------------- Constants & Helpers --------------------
-
-const orcidKid = '7hdmdswarosg3gjujo8agwtazgkp1ojs'
-const orcidBotomBread = '0x222c22737562223a22'
-const orcidTopBread = '0x222c22617574685f74696d65223a'
-
-const deployVerifyJWTContract = async (...args) => {
-  let VJWT = await ethers.getContractFactory('VerifyJWT')
-  return await upgrades.deployProxy(VJWT, args, {
-    initializer: 'initialize',
-  });
-}
-
-const sha256FromString = x => ethers.utils.sha256(ethers.utils.toUtf8Bytes(x))
-
-// Make sure it does bottomBread + id + topBread and does not allow any other text in between. If Google changes their JWT format so that the sandwich now contains other fields between bottomBread and topBread, this should fail until the contract is updated. 
-const sandwichIDWithBreadFromContract = async (id, contract) => {
-  let sandwich = (await contract.bottomBread()) + Buffer.from(id).toString('hex') + (await contract.topBread());
-  sandwich = sandwich.replaceAll('0x', '');
-  return sandwich
-}
-
-// Converts JWKS RSAkey to e and n:
-const jwksKeyToPubkey = (jwks) => {
-  let parsed = JSON.parse(jwks)
-  return [
-    ethers.BigNumber.from(Buffer.from(parsed['e'], 'base64url')), 
-    ethers.BigNumber.from(Buffer.from(parsed['n'], 'base64url'))
-  ]
-}
-
-//-------------------------------------------------
-
-
-
-describe.only("IdentityAggregator", function () {
-
-  // TODO: What's the best way to initialize contract variables before all tests, instead of initializing within every test?
+describe("IdentityAggregator", function () {
 
   describe("keywords", function () {
 
@@ -62,48 +32,32 @@ describe.only("IdentityAggregator", function () {
     });
     
     it("Should be updated when support for a new contract is added", async function () {
-      //--------------------------- Set up context ---------------------------
-      // get mock vjwt contract address
-      const [owner] = await ethers.getSigners()
-      const transactionCount = await owner.getTransactionCount()
-      const verifyJWTAddress = getContractAddress({
-        from: owner.address,
-        nonce: transactionCount
-      })
       const keyword = 'orcid';
-      await this.idAggregator.addPlatformContract(keyword, verifyJWTAddress);
-
-      //--------------------------- Run test ---------------------------
-
+      await this.idAggregator.addPlatformContract(keyword, "0xABCDEF1234567890ABCDEF1234567890ABCDEF12");
       expect(await this.idAggregator.getKeywords()).to.have.members([keyword]);
     });
   });
 
   describe("contractAddrForKeyword", function () {
+    
     it("Should be updated when support for a new contract is added", async function () {
-      //--------------------------- Set up context ---------------------------
-
-      const IdentityAggregator = await ethers.getContractFactory("IdentityAggregator");
-      const idAggregator = await IdentityAggregator.deploy();
-      await idAggregator.deployed();
+      const idAggregator = await deployIdAggregator();
+      const [owner] = await ethers.getSigners();
 
       // get contract address for VerifyJWT
-      const [owner] = await ethers.getSigners()
-      const transactionCount = await owner.getTransactionCount()
-      const futureAddress = getContractAddress({
+      const transactionCount = await owner.getTransactionCount();
+      const vjwtAddress = getContractAddress({
         from: owner.address,
         nonce: transactionCount
-      })
+      });
 
       vjwt = await deployVerifyJWTContract(11, 59, orcidKid, orcidBotomBread, orcidTopBread);
 
       const keyword = "orcid";
-      await idAggregator.addPlatformContract(keyword, futureAddress);
-
-      //--------------------------- Run test ---------------------------
+      await idAggregator.addPlatformContract(keyword, vjwtAddress);
 
       const verifyJWTAddress = await idAggregator.callStatic.contractAddrForKeyword(keyword);
-      expect(verifyJWTAddress).to.equal(futureAddress);
+      expect(verifyJWTAddress).to.equal(vjwtAddress);
     });
   });
 
@@ -111,17 +65,15 @@ describe.only("IdentityAggregator", function () {
     it("Should return array of supported creds", async function() {
       //--------------------------- Set up context ---------------------------
 
-      const IdentityAggregator = await ethers.getContractFactory("IdentityAggregator");
-      const idAggregator = await IdentityAggregator.deploy();
-      await idAggregator.deployed();
+      const idAggregator = await deployIdAggregator();
+      const [owner] = await ethers.getSigners();
 
       // get contract address for VerifyJWT
-      const [owner] = await ethers.getSigners()
-      const transactionCount = await owner.getTransactionCount()
+      const transactionCount = await owner.getTransactionCount();
       const vjwtAddress = getContractAddress({
         from: owner.address,
         nonce: transactionCount
-      })
+      });
 
       const [eOrcid, nOrcid] = jwksKeyToPubkey('{"kty":"RSA","e":"AQAB","use":"sig","kid":"production-orcid-org-7hdmdswarosg3gjujo8agwtazgkp1ojs","n":"jxTIntA7YvdfnYkLSN4wk__E2zf_wbb0SV_HLHFvh6a9ENVRD1_rHK0EijlBzikb-1rgDQihJETcgBLsMoZVQqGj8fDUUuxnVHsuGav_bf41PA7E_58HXKPrB2C0cON41f7K3o9TStKpVJOSXBrRWURmNQ64qnSSryn1nCxMzXpaw7VUo409ohybbvN6ngxVy4QR2NCC7Fr0QVdtapxD7zdlwx6lEwGemuqs_oG5oDtrRuRgeOHmRps2R6gG5oc-JqVMrVRv6F9h4ja3UgxCDBQjOVT1BFPWmMHnHCsVYLqbbXkZUfvP2sO1dJiYd_zrQhi-FtNth9qrLLv3gkgtwQ"}');
       const vjwt = await deployVerifyJWTContract(eOrcid, nOrcid, orcidKid, orcidBotomBread, orcidTopBread);

--- a/backend/test/identityAggregator.js
+++ b/backend/test/identityAggregator.js
@@ -17,7 +17,7 @@ const {
 } = require('./utils/utils');
 
 
-describe.only("IdentityAggregator", function () {
+describe("IdentityAggregator", function () {
 
   describe("keywords", function () {
     before(async function () {

--- a/backend/test/identityAggregator.js
+++ b/backend/test/identityAggregator.js
@@ -33,7 +33,7 @@ describe("IdentityAggregator", function () {
     
     it("Should be updated when support for a new contract is added", async function () {
       const keyword = 'orcid';
-      await this.idAggregator.addPlatformContract(keyword, "0xABCDEF1234567890ABCDEF1234567890ABCDEF12");
+      await this.idAggregator.addVerifyJWTContract(keyword, "0xABCDEF1234567890ABCDEF1234567890ABCDEF12");
       expect(await this.idAggregator.getKeywords()).to.have.members([keyword]);
     });
   });
@@ -54,7 +54,7 @@ describe("IdentityAggregator", function () {
       vjwt = await deployVerifyJWTContract(11, 59, orcidKid, orcidBotomBread, orcidTopBread);
 
       const keyword = "orcid";
-      await idAggregator.addPlatformContract(keyword, vjwtAddress);
+      await idAggregator.addVerifyJWTContract(keyword, vjwtAddress);
 
       const verifyJWTAddress = await idAggregator.callStatic.contractAddrForKeyword(keyword);
       expect(verifyJWTAddress).to.equal(vjwtAddress);
@@ -95,7 +95,7 @@ describe("IdentityAggregator", function () {
       await vjwt.verifyMe(ethers.BigNumber.from(signature), message, payloadIdx, startIdx, endIdx, '0x'+sandwich);
       
       const keyword = "orcid";
-      await idAggregator.addPlatformContract(keyword, vjwtAddress);
+      await idAggregator.addVerifyJWTContract(keyword, vjwtAddress);
 
       const allAccounts = await idAggregator.callStatic.getAllAccounts(owner.address);
       const creds = hexToString(allAccounts[0]);

--- a/backend/test/utils/utils.js
+++ b/backend/test/utils/utils.js
@@ -1,5 +1,7 @@
 const { ethers } = require('hardhat');
 
+exports.vmExceptionStr = 'VM Exception while processing transaction: reverted with reason string ';
+
 exports.orcidKid = '7hdmdswarosg3gjujo8agwtazgkp1ojs';
 exports.orcidBotomBread = '0x222c22737562223a22';
 exports.orcidTopBread = '0x222c22617574685f74696d65223a';

--- a/backend/test/utils/utils.js
+++ b/backend/test/utils/utils.js
@@ -1,0 +1,44 @@
+const { ethers } = require('hardhat');
+
+exports.orcidKid = '7hdmdswarosg3gjujo8agwtazgkp1ojs';
+exports.orcidBotomBread = '0x222c22737562223a22';
+exports.orcidTopBread = '0x222c22617574685f74696d65223a';
+
+exports.googleKid = '729189450d49028570425266f03e737f45af2932'
+exports.googleBottomBread = '0x222c22656d61696c223a22'
+exports.googleTopBread = '0x222c22656d61696c5f7665726966696564223a'
+
+exports.deployVerifyJWTContract = async (...args) => {
+  let VJWT = await ethers.getContractFactory('VerifyJWT')
+  return await upgrades.deployProxy(VJWT, args, {
+    initializer: 'initialize',
+  });
+}
+
+exports.deployIdAggregator = async () => {
+  const IdentityAggregator = await ethers.getContractFactory("IdentityAggregator");
+  const idAggregator = await IdentityAggregator.deploy();
+  await idAggregator.deployed();
+  return idAggregator;
+}
+
+// input: x (string); output: keccak256 of string
+exports.sha256FromString = x => ethers.utils.sha256(ethers.utils.toUtf8Bytes(x))
+// input: x (string); output: sha256 of string
+exports.keccak256FromString = x => ethers.utils.keccak256(ethers.utils.toUtf8Bytes(x))
+
+// Make sure it does bottomBread + id + topBread and does not allow any other text in between. If Google changes their JWT format so that the sandwich now contains other fields between bottomBread and topBread, this should fail until the contract is updated. 
+exports.sandwichIDWithBreadFromContract = async (id, contract) => {
+  let sandwich = (await contract.bottomBread()) + Buffer.from(id).toString('hex') + (await contract.topBread());
+  sandwich = sandwich.replaceAll('0x', '');
+  return sandwich
+}
+
+// Converts JWKS RSAkey to e and n:
+exports.jwksKeyToPubkey = (jwks) => {
+  let parsed = JSON.parse(jwks)
+  return [
+    ethers.BigNumber.from(Buffer.from(parsed['e'], 'base64url')), 
+    ethers.BigNumber.from(Buffer.from(parsed['n'], 'base64url'))
+  ]
+}


### PR DESCRIPTION
Clean up code and add tests as discussed during stand up this morning (April 2, 2022). Create utils file for constants and helper functions used in tests. Add to IdentityAggregator test suite. Remove notes and getCredsForCreds function from IdentityAggregator. 